### PR TITLE
Inline wordLengths function

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,9 +34,6 @@ const wrapAnsiCode = (code: number): string =>
 const wrapAnsiHyperlink = (url: string): string =>
   `${ESC}${ANSI_ESCAPE_LINK}${url}${ANSI_ESCAPE_BELL}`;
 
-const wordLengths = (words: string[]): number[] =>
-  words.map((character) => stringWidth(character));
-
 const wrapWord = (rows: string[], word: string, columns: number) => {
   const characters = word[Symbol.iterator]();
 
@@ -141,7 +138,7 @@ const exec = (
   let escapeUrl;
 
   const words = string.split(' ');
-  const lengths = wordLengths(words);
+  const lengths = words.map((character) => stringWidth(character));
   let rows = [''];
 
   for (const [index, word] of words.entries()) {


### PR DESCRIPTION
Saves whopping 10 bytes after minification using Rolldown (2216 bytes vs 2106 bytes).