### PR TITLE
Fix inconsistent Node.js version used in Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.x
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
       - name: Install Dependencies
         run: npm ci
       - name: Lint
@@ -35,8 +37,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
       - run: npm ci
       - run: npm run build
       - run: npm version ${TAG_NAME} --git-tag-version=false


### PR DESCRIPTION
Build was using Node.js 20, publish was using Node.js 22, and only one of the jobs benefitted from cache.