### PR TITLE
Separate lint from test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,22 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node v22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -19,9 +35,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
       - name: Install Dependencies
         run: npm ci
-      - name: Lint
-        run: npm run lint
       - name: Test
         run: npm run test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Use Node v22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22.x
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Lint
         run: npm run lint
 
@@ -38,6 +38,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Test
         run: npm run test


### PR DESCRIPTION
Previously, we were linting 3 times, on each Node.js version. Now, linting is done once, while tests continue to run on all supported Node.js versions.