### PR TITLE
Remove browser globals from ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,6 @@
 import eslintjs from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import {defineConfig} from 'eslint/config';
-import globals from "globals";
 
 export default defineConfig([
   {
@@ -9,11 +8,6 @@ export default defineConfig([
     plugins: {
       eslint: eslintjs,
       typescript: tseslint
-    },
-    languageOptions: {
-      globals: {
-        ...globals.browser
-      }
     },
     extends: [
       tseslint.configs.strict,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@types/node": "^24.2.0",
         "eslint": "^9.32.0",
         "fast-wrap-ansi-prod": "npm:fast-wrap-ansi@*",
-        "globals": "^16.3.0",
         "prettier": "^3.6.2",
         "tinybench": "^4.0.1",
         "typescript": "^5.8.3",
@@ -1115,19 +1114,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/globals": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graphemer": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/node": "^24.2.0",
     "eslint": "^9.32.0",
     "fast-wrap-ansi-prod": "npm:fast-wrap-ansi@*",
-    "globals": "^16.3.0",
     "prettier": "^3.6.2",
     "tinybench": "^4.0.1",
     "typescript": "^5.8.3",


### PR DESCRIPTION
This code is meant to run on non-browser environments, so not only having these globals configured is unnecessary, but also potentially harmful, as one may accidentally use some browser global and ESLint would be happy about it.