### PR TITLE
fix running tests on Node versions older than 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /lib
+/test/*.test.js

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "format": "prettier --write src test",
     "lint": "eslint src test && prettier --check src test",
     "build": "tsc",
-    "test": "node --test"
+    "test": "tsc ./test/*.test.ts && node --test",
+    "bench": "npm run build && node ./scripts/bench.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",


### PR DESCRIPTION
Node 24 is the only version to have type stripping enabled by default. Node 22 supports it with the flag but Node 18 & 20 don't support the flag.

This PR will fail CI since there is a failing test that wasn't caught previously since tests weren't running correctly.